### PR TITLE
Parallelized OSRM table fallback

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ import os  # para acessar variáveis de ambiente, se for usar outras APIs
 import requests  # para chamadas HTTP (Overpass, OSRM, Open-Elevation)
 from requests.adapters import HTTPAdapter  # para configurar retries automáticos
 from urllib3.util.retry import Retry  # política de retry (backoff)
+from concurrent.futures import ThreadPoolExecutor  # para paralelizar requests
 import folium  # para desenhar mapas interativos e marcadores
 import ipywidgets as widgets  # para UI interativa no Colab
 from tqdm.notebook import tqdm  # para barras de progresso
@@ -219,16 +220,18 @@ def osrm_table(latlons, timeout=30):
         resp.raise_for_status()
         return resp.json().get("distances", [])
     except (requests.exceptions.ReadTimeout, requests.exceptions.HTTPError):
-        # quebra em n requisições para cada fonte
-        full = []
-        for i in range(len(latlons)):
+        # dispara uma requisição por fonte em paralelo
+        def fetch_row(idx):
             r = session.get(
                 url,
-                params={"annotations": "distance", "sources": i},
-                timeout=timeout
+                params={"annotations": "distance", "sources": idx},
+                timeout=timeout,
             )
             r.raise_for_status()
-            full.append(r.json().get("distances", [[0]*len(latlons)])[0])
+            return r.json().get("distances", [[0]*len(latlons)])[0]
+
+        with ThreadPoolExecutor() as ex:
+            full = list(ex.map(fetch_row, range(len(latlons))))
         return full
 
 # -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- parallelize fallback OSRM table requests
- add `ThreadPoolExecutor` import

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_687e65cc0e0883319972dfa2041e3f2c