### PR TITLE
Add advanced TSP solver options

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,12 @@ Execute `main.py` a partir de um notebook (Colab ou Jupyter):
 
 Uma interface será exibida para seleção de cidade e POIs. Ao final do processamento será gerado o arquivo `rota_otimizada.html` com o mapa da rota otimizada.
 
+### Algoritmos de Roteirização
+
+O módulo `optimization.py` oferece diferentes estratégias para resolver o TSP. Além de `solve_tsp`, que utiliza a busca padrão do OR-Tools, estão disponíveis:
+
+- `solve_tsp_guided_local_search` – utiliza a metaheurística *GUIDED_LOCAL_SEARCH* do OR-Tools.
+- `christofides_tsp` – retorna uma rota aproximada pelo algoritmo de Christofides fornecido pelo NetworkX.
+
+Esses métodos permitem comparar rapidamente a qualidade das rotas geradas.
+

--- a/optimization.py
+++ b/optimization.py
@@ -1,5 +1,7 @@
 from typing import List
 
+import networkx as nx
+
 from ortools.constraint_solver import pywrapcp, routing_enums_pb2
 
 
@@ -49,3 +51,99 @@ def solve_tsp(dist_matrix: List[List[float]], start: int, end: int, time_limit_s
     return route
 
 __all__ = ["solve_tsp"]
+
+
+def solve_tsp_guided_local_search(
+    dist_matrix: List[List[float]], start: int, end: int, time_limit_s: int = 5
+) -> List[int] | None:
+    """Resolve o TSP usando GUIDED_LOCAL_SEARCH do OR-Tools.
+
+    Parameters
+    ----------
+    dist_matrix:
+        Matriz de distâncias entre os pontos.
+    start:
+        Índice do ponto de partida.
+    end:
+        Índice do destino final.
+    time_limit_s:
+        Tempo limite de busca em segundos.
+
+    Returns
+    -------
+    list[int] | None
+        Ordem dos índices a serem visitados ou ``None`` em caso de falha.
+    """
+
+    n = len(dist_matrix)
+    mgr = pywrapcp.RoutingIndexManager(n, 1, [start], [end])
+    routing = pywrapcp.RoutingModel(mgr)
+
+    def cb(i: int, j: int) -> int:
+        return int(dist_matrix[mgr.IndexToNode(i)][mgr.IndexToNode(j)])
+
+    idx = routing.RegisterTransitCallback(cb)
+    routing.SetArcCostEvaluatorOfAllVehicles(idx)
+
+    params = pywrapcp.DefaultRoutingSearchParameters()
+    params.first_solution_strategy = routing_enums_pb2.FirstSolutionStrategy.PATH_CHEAPEST_ARC
+    params.local_search_metaheuristic = routing_enums_pb2.LocalSearchMetaheuristic.GUIDED_LOCAL_SEARCH
+    params.time_limit.seconds = time_limit_s
+
+    sol = routing.SolveWithParameters(params)
+    if not sol:
+        return None
+
+    route = []
+    index = routing.Start(0)
+    while not routing.IsEnd(index):
+        route.append(mgr.IndexToNode(index))
+        index = sol.Value(routing.NextVar(index))
+    route.append(mgr.IndexToNode(index))
+    return route
+
+
+def christofides_tsp(dist_matrix: List[List[float]], start: int, end: int) -> List[int]:
+    """Aproxima o TSP via algoritmo de Christofides da NetworkX.
+
+    Esta função ignora ``time_limit_s`` e sempre retorna um ciclo começando em
+    ``start``. O ``end`` é reposicionado para o final da lista.
+
+    Parameters
+    ----------
+    dist_matrix:
+        Matriz de distâncias entre os pontos.
+    start:
+        Índice do ponto de partida.
+    end:
+        Índice do destino final.
+
+    Returns
+    -------
+    list[int]
+        Ordem aproximada dos índices a serem visitados.
+    """
+
+    n = len(dist_matrix)
+    g = nx.Graph()
+    for i in range(n):
+        for j in range(i + 1, n):
+            g.add_edge(i, j, weight=dist_matrix[i][j])
+
+    cycle = nx.approximation.christofides(g, weight="weight")
+
+    # reordena para comecar em start e terminar em end
+    if start in cycle:
+        while cycle[0] != start:
+            cycle.append(cycle.pop(0))
+    if end in cycle:
+        while cycle[-1] != end:
+            cycle.append(cycle.pop(0))
+    else:
+        # remove retorno ao inicio e adiciona end no final
+        cycle = cycle[:-1] + [end]
+
+    return cycle
+
+
+__all__.extend(["solve_tsp_guided_local_search", "christofides_tsp"])

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ tqdm
 aiohttp
 python-dotenv
 loguru
+networkx


### PR DESCRIPTION
## Summary
- add solver using GUIDED_LOCAL_SEARCH metaheuristic
- support Christofides approximation via networkx
- document new solver functions
- include networkx as a dependency

## Testing
- `python -m py_compile *.py`
- ❌ `pip install networkx` (failed due to network access)


------
https://chatgpt.com/codex/tasks/task_e_687e9f246a688331bebd73c4df06ed41