### PR TITLE
Add initial tests and benchmark script

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,19 @@ O módulo `optimization.py` oferece diferentes estratégias para resolver o TSP.
 
 Esses métodos permitem comparar rapidamente a qualidade das rotas geradas.
 
+
+## Testes
+
+Execute a suíte de testes com `pytest`:
+
+```bash
+pytest -q
+```
+
+## Benchmarks
+
+Um script simples `benchmark.py` mede o tempo de execução dos solvers do TSP:
+
+```bash
+python benchmark.py
+```

--- a/benchmark.py
+++ b/benchmark.py
@@ -1,0 +1,27 @@
+import time
+
+try:
+    from optimization import solve_tsp, solve_tsp_guided_local_search, christofides_tsp
+except Exception as exc:
+    raise SystemExit(f"Dependencies missing: {exc}")
+
+DIST = [
+    [0, 2, 9, 10],
+    [1, 0, 6, 4],
+    [15, 7, 0, 8],
+    [6, 3, 12, 0],
+]
+
+
+def bench(func, name, loops=100):
+    t0 = time.perf_counter()
+    for _ in range(loops):
+        func(DIST, 0, 3)
+    t1 = time.perf_counter()
+    print(f"{name}: {t1 - t0:.4f}s over {loops} runs")
+
+
+if __name__ == "__main__":
+    bench(solve_tsp, "solve_tsp")
+    bench(solve_tsp_guided_local_search, "solve_tsp_guided_local_search")
+    bench(christofides_tsp, "christofides_tsp")

--- a/tests/test_data_fetch.py
+++ b/tests/test_data_fetch.py
@@ -1,0 +1,27 @@
+from unittest import mock
+import requests
+import data_fetch
+
+class FakeResp:
+    def __init__(self, data):
+        self._data = data
+    def raise_for_status(self):
+        pass
+    def json(self):
+        return self._data
+
+def test_osrm_table_success():
+    resp = FakeResp({"distances": [[0, 1], [1, 0]]})
+    with mock.patch('data_fetch.session.get', return_value=resp):
+        result = data_fetch.osrm_table([(0,0), (1,1)])
+        assert result == [[0,1],[1,0]]
+
+def test_osrm_table_fallback():
+    def side_effect(url, params=None, timeout=None):
+        if 'sources' in params:
+            idx = params['sources']
+            return FakeResp({"distances": [[idx*10, idx*10 + 1]]})
+        raise requests.RequestException('fail')
+    with mock.patch('data_fetch.session.get', side_effect=side_effect):
+        result = data_fetch.osrm_table([(0,0), (1,1)])
+        assert result == [[0,1],[10,11]]

--- a/tests/test_geocoding.py
+++ b/tests/test_geocoding.py
@@ -1,0 +1,37 @@
+import types
+from unittest import mock
+import geocoding
+
+class FakeLoc:
+    def __init__(self, lat, lon):
+        self.latitude = lat
+        self.longitude = lon
+        self.raw = {}
+
+
+def test_dentro_da_cidade_true():
+    bbox = (-10, 10, -20, 20)
+    assert geocoding.dentro_da_cidade(0, 0, bbox)
+
+def test_dentro_da_cidade_false():
+    bbox = (-10, 10, -20, 20)
+    assert not geocoding.dentro_da_cidade(15, 0, bbox)
+
+def test_geocode_strict_cache():
+    fake = FakeLoc(1.0, 2.0)
+    with mock.patch('geocoding.geocode_rl', return_value=fake) as mg:
+        with mock.patch('geocoding.get_city_bbox', return_value=(-2,2,-2,2)):
+            geocoding._cache_geo.clear()
+            r1 = geocoding.geocode_strict_single('addr', 'city')
+            r2 = geocoding.geocode_strict_single('addr', 'city')
+            assert r1 == (1.0, 2.0)
+            assert r2 == (1.0, 2.0)
+            assert mg.call_count == 1
+
+def test_geocode_fallback_photon():
+    fake = FakeLoc(3.0, 4.0)
+    with mock.patch('geocoding.geocode_rl', return_value=None):
+        with mock.patch('geocoding.photon_geocode_rl', return_value=fake):
+            geocoding._cache_geo.clear()
+            result = geocoding.geocode_fallback_single('addr', 'city')
+            assert result == (3.0, 4.0)

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -1,0 +1,32 @@
+import pytest
+
+opt = pytest.importorskip('optimization')
+
+DIST = [
+    [0, 2, 9, 10],
+    [1, 0, 6, 4],
+    [15, 7, 0, 8],
+    [6, 3, 12, 0],
+]
+
+
+def _check_route(route):
+    assert route[0] == 0
+    assert route[-1] == 3
+    assert set(route) == {0,1,2,3}
+    assert len(route) == 4
+
+
+def test_solve_tsp():
+    r = opt.solve_tsp(DIST, 0, 3)
+    _check_route(r)
+
+
+def test_solve_tsp_gls():
+    r = opt.solve_tsp_guided_local_search(DIST, 0, 3)
+    _check_route(r)
+
+
+def test_christofides_tsp():
+    r = opt.christofides_tsp(DIST, 0, 3)
+    _check_route(r)


### PR DESCRIPTION
## Summary
- add unit tests for geocoding, OSRM table and solver logic
- add a benchmark script for solver functions
- document how to run tests and benchmarks

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*
- `python benchmark.py` *(fails: Dependencies missing: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_e_687ea0a0708083319f9d75dd13364ffb