### PR TITLE
Add async IO utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ Execute `main.py` a partir de um notebook (Colab ou Jupyter):
 %run main.py
 ```
 
+Para cenários onde a latência das chamadas HTTP seja relevante, o módulo
+`async_fetch.py` disponibiliza versões assíncronas das funções de coleta de
+dados. Elas utilizam `aiohttp` e podem ser chamadas dentro de um loop
+`asyncio` para maior desempenho.
+
 Uma interface será exibida para seleção de cidade e POIs. Ao final do processamento será gerado o arquivo `rota_otimizada.html` com o mapa da rota otimizada.
 
 ### Algoritmos de Roteirização

--- a/async_fetch.py
+++ b/async_fetch.py
@@ -1,0 +1,198 @@
+import asyncio
+import logging
+from typing import List, Tuple
+
+import aiohttp
+
+from geocoding import get_city_bbox, dentro_da_cidade
+
+log = logging.getLogger(__name__)
+
+_session: aiohttp.ClientSession | None = None
+
+
+def get_session() -> aiohttp.ClientSession:
+    """Retorna uma sessão ``aiohttp`` reutilizável."""
+    global _session
+    if _session is None or _session.closed:
+        _session = aiohttp.ClientSession()
+    return _session
+
+
+async def close_session() -> None:
+    """Encerra a sessão HTTP assíncrona."""
+    global _session
+    if _session and not _session.closed:
+        await _session.close()
+    _session = None
+
+
+async def coletar_pois_async(cidade: str) -> List[dict]:
+    """Busca bares e restaurantes via Overpass de forma assíncrona."""
+    bbox = get_city_bbox(cidade)
+    if bbox:
+        s, n, w, e = bbox
+        q = f"""
+        [out:json][timeout:60];
+        (
+          node[\"amenity\"=\"bar\"]({s},{w},{n},{e});
+          node[\"bar\"=\"yes\"]({s},{w},{n},{e});
+          node[\"craft\"=\"brewery\"]({s},{w},{n},{e});
+          node[\"shop\"=\"alcohol\"]({s},{w},{n},{e});
+          node[\"amenity\"=\"pub\"]({s},{w},{n},{e});
+          node[\"amenity\"=\"cafe\"]({s},{w},{n},{e});
+          node[\"amenity\"=\"fast_food\"]({s},{w},{n},{e});
+          node[\"amenity\"=\"nightclub\"]({s},{w},{n},{e});
+        );
+        out center tags;
+        """
+    else:
+        q = f"""
+        [out:json][timeout:60];
+        area[\"name\"=\"{cidade}\"][boundary=\"administrative\"][admin_level=\"8\"]->.a;
+        (
+          node[\"amenity\"=\"bar\"](area.a);
+          way[\"amenity\"=\"bar\"](area.a);
+          rel[\"amenity\"=\"bar\"](area.a);
+        );
+        out center tags;
+        """
+
+    session = get_session()
+    try:
+        async with session.post(
+            "http://overpass-api.de/api/interpreter", data={"data": q}, timeout=60
+        ) as resp:
+            resp.raise_for_status()
+            elements = (await resp.json()).get("elements", [])
+    except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+        log.error(f"Erro Overpass: {e}")
+        return []
+    except Exception as e:
+        log.error(f"Erro ao decodificar resposta Overpass: {e}")
+        return []
+
+    pois = []
+    for el in elements:
+        name = el.get("tags", {}).get("name")
+        lat = el.get("lat") or el.get("center", {}).get("lat")
+        lon = el.get("lon") or el.get("center", {}).get("lon")
+        if not (name and lat and lon):
+            continue
+        if bbox and not dentro_da_cidade(lat, lon, bbox):
+            continue
+        pois.append({"name": name, "lat": float(lat), "lon": float(lon)})
+    return pois
+
+
+async def batch_altitude_async(latlons: List[Tuple[float, float]]) -> List[float]:
+    """Obtém altitudes via Open-Elevation de forma assíncrona."""
+    locs = [{"latitude": lat, "longitude": lon} for lat, lon in latlons]
+    session = get_session()
+    try:
+        async with session.post(
+            "https://api.open-elevation.com/api/v1/lookup",
+            json={"locations": locs},
+            timeout=30,
+        ) as resp:
+            resp.raise_for_status()
+            data = (await resp.json()).get("results", [])
+            return [r.get("elevation", 0) for r in data]
+    except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+        log.error(f"Erro Open-Elevation: {e}")
+    except Exception as e:
+        log.error(f"Erro ao processar resposta Open-Elevation: {e}")
+    return [0] * len(locs)
+
+
+async def osrm_table_async(
+    latlons: List[Tuple[float, float]], timeout: int = 30
+) -> List[List[float]]:
+    """Retorna matriz de distâncias usando OSRM de forma assíncrona."""
+    coord_str = ";".join(f"{lon},{lat}" for lat, lon in latlons)
+    url = f"http://router.project-osrm.org/table/v1/foot/{coord_str}"
+    params = {"annotations": "distance"}
+    session = get_session()
+    try:
+        async with session.get(url, params=params, timeout=timeout) as resp:
+            resp.raise_for_status()
+            return (await resp.json()).get("distances", [])
+    except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+        log.warning(f"OSRM Table falhou, tentando linha a linha: {e}")
+
+        async def fetch_row(i: int) -> Tuple[int, List[float] | None]:
+            try:
+                async with session.get(
+                    url,
+                    params={"annotations": "distance", "sources": i},
+                    timeout=timeout,
+                ) as r:
+                    r.raise_for_status()
+                    row = (await r.json()).get("distances", [[0] * len(latlons)])[0]
+                    return i, row
+            except Exception as exc:
+                log.error(f"OSRM Table linha {i} falhou: {exc}")
+                return i, None
+
+        tasks = [fetch_row(i) for i in range(len(latlons))]
+        results = [None] * len(latlons)
+        for idx, row in await asyncio.gather(*tasks):
+            if row is None:
+                return [[0] * len(latlons) for _ in latlons]
+            results[idx] = row
+        return results
+    except Exception as e:
+        log.error(f"Erro ao processar resposta OSRM: {e}")
+        return [[0] * len(latlons) for _ in latlons]
+
+
+async def fetch_route_geometry_async(
+    a: Tuple[float, float], b: Tuple[float, float]
+) -> List[Tuple[float, float]]:
+    """Busca linha de caminho entre dois pontos via OSRM de forma assíncrona."""
+    url = f"http://router.project-osrm.org/route/v1/foot/{a[1]},{a[0]};{b[1]},{b[0]}"
+    session = get_session()
+    try:
+        async with session.get(
+            url, params={"overview": "full", "geometries": "geojson"}, timeout=30
+        ) as resp:
+            resp.raise_for_status()
+            coords = (await resp.json())["routes"][0]["geometry"]["coordinates"]
+            return [(lat, lng) for lng, lat in coords]
+    except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+        log.error(f"Erro OSRM Route: {e}")
+    except Exception as e:
+        log.error(f"Erro ao processar resposta OSRM Route: {e}")
+    return []
+
+
+async def fetch_route_geometry_multi_async(
+    points: List[Tuple[float, float]]
+) -> List[Tuple[float, float]]:
+    """Obtém a geometria de uma rota que passa por ``points`` de forma assíncrona."""
+    coord_str = ";".join(f"{lon},{lat}" for lat, lon in points)
+    url = f"http://router.project-osrm.org/route/v1/foot/{coord_str}"
+    session = get_session()
+    try:
+        async with session.get(
+            url, params={"overview": "full", "geometries": "geojson"}, timeout=30
+        ) as resp:
+            resp.raise_for_status()
+            coords = (await resp.json())["routes"][0]["geometry"]["coordinates"]
+            return [(lat, lng) for lng, lat in coords]
+    except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+        log.error(f"Erro OSRM Route múltiplo: {e}")
+    except Exception as e:
+        log.error(f"Erro ao processar resposta OSRM Route múltiplo: {e}")
+    return []
+
+
+__all__ = [
+    "coletar_pois_async",
+    "batch_altitude_async",
+    "osrm_table_async",
+    "fetch_route_geometry_async",
+    "fetch_route_geometry_multi_async",
+    "close_session",
+    "get_session",
+]

--- a/tests/test_async_fetch.py
+++ b/tests/test_async_fetch.py
@@ -1,0 +1,52 @@
+import aiohttp
+import pytest
+from unittest import mock
+
+import async_fetch
+
+
+class FakeResp:
+    def __init__(self, data):
+        self._data = data
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    def raise_for_status(self):
+        pass
+
+    async def json(self):
+        return self._data
+
+
+@pytest.mark.asyncio
+async def test_osrm_table_async_success():
+    resp = FakeResp({"distances": [[0, 1], [1, 0]]})
+
+    class FakeSession:
+        async def get(self, *args, **kwargs):
+            return resp
+
+    with mock.patch("async_fetch.get_session", return_value=FakeSession()):
+        result = await async_fetch.osrm_table_async([(0, 0), (1, 1)])
+        assert result == [[0, 1], [1, 0]]
+
+
+@pytest.mark.asyncio
+async def test_osrm_table_async_fallback():
+    async def fake_get(url, params=None, timeout=None):
+        if params and "sources" in params:
+            idx = params["sources"]
+            return FakeResp({"distances": [[idx * 10, idx * 10 + 1]]})
+        raise aiohttp.ClientError("fail")
+
+    class FakeSession:
+        async def get(self, url, params=None, timeout=None):
+            return await fake_get(url, params=params, timeout=timeout)
+
+    with mock.patch("async_fetch.get_session", return_value=FakeSession()):
+        result = await async_fetch.osrm_table_async([(0, 0), (1, 1)])
+        assert result == [[0, 1], [10, 11]]


### PR DESCRIPTION
## Summary
- add `async_fetch.py` with aiohttp implementations
- document async usage in README
- test async OSRM table

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_687ea253a4e88331a6405d7f9ce38b5c