### PR TITLE
Enforce city boundaries using Overpass polygons

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ python-dotenv
 loguru
 networkx
 pytest-asyncio
+shapely


### PR DESCRIPTION
## Summary
- restrict POI queries to administrative areas when available
- discard POIs with mismatching `addr:city`
- validate geocoded addresses against city name and polygon
- expose helpers for Overpass area id and city polygon
- update requirements and tests for new behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_687eae0882a08331ad6bcecd11f60497