### PR TITLE
Fix imports and ensure file endings

### DIFF
--- a/geocoding.py
+++ b/geocoding.py
@@ -2,6 +2,8 @@ import logging
 from functools import lru_cache
 from typing import Optional, Tuple, Any
 
+import requests
+
 try:  # Shapely é opcional
     from shapely.geometry import Polygon, Point
 except Exception:  # pragma: no cover - biblioteca ausente

--- a/mapping.py
+++ b/mapping.py
@@ -8,10 +8,6 @@ from data_fetch import session
 
 log = logging.getLogger(__name__)
 
-from data_fetch import session
-
-log = logging.getLogger(__name__)
-
 
 def fetch_route_geometry(a: Tuple[float, float], b: Tuple[float, float]) -> List[Tuple[float, float]]:
     """Busca linha de caminho entre dois pontos via OSRM."""


### PR DESCRIPTION
## Summary
- clean duplicate imports in `mapping.py`
- import `requests` in `geocoding.py`
- ensure files end with a newline

## Testing
- `pytest -q` *(fails: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_687f9f38574c833189d33dbd65d3b483